### PR TITLE
Raise TractiveError correctly

### DIFF
--- a/aiotractive/api.py
+++ b/aiotractive/api.py
@@ -117,6 +117,8 @@ class API:  # pylint: disable=too-many-instance-attributes
                         raise UnauthorizedError from error
                 except Exception as error:
                     raise TractiveError from error
+        except TractiveError as error:
+            raise error
         except Exception as error:
             raise TractiveError from error
 


### PR DESCRIPTION
Currently
`raise UnauthorizedError from error`
will be captured by `except Exception as error:` and raised as `TractiveError `
