### PR TITLE
Improve reliability (keep alive timeout issue)

### DIFF
--- a/aiotractive/channel.py
+++ b/aiotractive/channel.py
@@ -12,8 +12,8 @@ class Channel:
     CHANNEL_URL = "https://channel.tractive.com/3/channel"
     IGNORE_MESSAGES = ["handshake", "keep-alive"]
 
-    KEEP_ALIVE_TIMEOUT = 7  # seconds
-    CHECK_CONNECTION_TIME = 4  # seconds
+    KEEP_ALIVE_TIMEOUT = 60  # seconds
+    CHECK_CONNECTION_TIME = 5  # seconds
 
     def __init__(self, api):
         self._api = api

--- a/aiotractive/channel.py
+++ b/aiotractive/channel.py
@@ -53,7 +53,7 @@ class Channel:
                 async with self._api.session.request(
                     "POST", self.CHANNEL_URL, headers=await self._api.auth_headers()
                 ) as response:
-                    async for data, _ in response.content.iter_chunks():
+                    async for data in response.content:
                         event = json.loads(data)
                         if event["message"] == "keep-alive":
                             self._last_keep_alive = time.time()


### PR DESCRIPTION
- Increase `KEEP_ALIVE_TIMEOUT` to `60s`
- Iterate response lines instead of chunks (current logic can break if multiple messages received at once)

--- 
I was getting frequent `Tractive is not available. Internet connection is down? Sleeping 10 seconds and retrying` errors in my home assistant.

Turns out, Tractive api occasionally "restarts" the stream by sending a new "handshake" message. In such scenarios, the duration between keep-alive messages is ~10s which is higher than current 7s.
Logs:
```
2023-08-21 23:30:08.103680
b'{"message":"keep-alive", ...}\n'

2023-08-21 23:30:11.142572
b'{"message":"tracker_status", ...}\n'

2023-08-21 23:30:13.833765
b'{"message":"handshake", ...}\n'

2023-08-21 23:30:14.025513
b'{"message":"tracker_status", ...}\n'

2023-08-21 23:30:14.177498
b'{"message":"activity_update", ...}\n'

2023-08-21 23:30:14.223398
b'{"message":"wellness_overview", ...}\n'

2023-08-21 23:30:16.379405 <<CURRENT LOGIC TIMES OUT HERE>>

2023-08-21 23:30:16.703810
b'{"message":"tracker_status", ...}\n'

2023-08-21 23:30:18.833432
b'{"message":"keep-alive", ...}\n'
```