### PR TITLE
Wait and retry if too many requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/aiotractive/api.py
+++ b/aiotractive/api.py
@@ -13,7 +13,6 @@ from yarl import URL
 from .exceptions import NotFoundError, TractiveError, UnauthorizedError
 
 CLIENT_ID = "625e533dc3c3b41c28a669f0"
-LIMIT_EXCEEDED_SLEEP = 3
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/aiotractive/api.py
+++ b/aiotractive/api.py
@@ -75,9 +75,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         except Exception as error:
             raise TractiveError from error
 
-    async def raw_request(
-        self, uri, params=None, data=None, method="GET", attempt: int = 1
-    ):
+    async def raw_request(self, uri, params=None, data=None, method="GET", attempt: int = 1):
         """Perform request."""
         async with self.session.request(
             method,
@@ -93,9 +91,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                     delay = self._retry_delay(attempt)
                     _LOGGER.info("Request limit exceeded, retrying in %s second", delay)
                     await asyncio.sleep(delay)
-                    return await self.raw_request(
-                        uri, params, data, method, attempt=attempt + 1
-                    )
+                    return await self.raw_request(uri, params, data, method, attempt=attempt + 1)
                 raise TractiveError("Request limit exceeded")
 
             if "Content-Type" in response.headers and "application/json" in response.headers["Content-Type"]:

--- a/aiotractive/api.py
+++ b/aiotractive/api.py
@@ -98,8 +98,6 @@ class API:  # pylint: disable=too-many-instance-attributes
                     )
                 raise TractiveError("Request limit exceeded")
 
-            self._attempt = 0
-
             if "Content-Type" in response.headers and "application/json" in response.headers["Content-Type"]:
                 return await response.json()
             return await response.read()

--- a/aiotractive/api.py
+++ b/aiotractive/api.py
@@ -33,7 +33,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         loop=None,
         session=None,
         retry_count=3,
-        retry_delay=lambda attempt: (attempt + 1) ** 2 + random.uniform(0, 3),
+        retry_delay=lambda attempt: 3**attempt + random.uniform(0, 3),
     ):
         self._login = login
         self._password = password

--- a/aiotractive/api.py
+++ b/aiotractive/api.py
@@ -75,7 +75,9 @@ class API:  # pylint: disable=too-many-instance-attributes
         except Exception as error:
             raise TractiveError from error
 
-    async def raw_request(self, uri, params=None, data=None, method="GET", attempt: int = 1):
+    async def raw_request(  # pylint: disable=too-many-arguments
+        self, uri, params=None, data=None, method="GET", attempt: int = 1
+    ):
         """Perform request."""
         async with self.session.request(
             method,


### PR DESCRIPTION
A user with 5 trackers configured with his Tractive account reported a problem with the `Too Many Requests` API response: https://github.com/home-assistant/core/issues/99121#issuecomment-1702549320 I'm trying to find the perfect sleep value when we reach the limit of allowed requests.

@hupfis Sorry to disturb you. If I understand correctly, you have direct contact with Tractive. Maybe you can give some hint how long we should wait before making another request if we get `Too Many Requests` response?