### PR TITLE
Keep channel connection open longer than default 5 minutes

### DIFF
--- a/aiotractive/channel.py
+++ b/aiotractive/channel.py
@@ -3,6 +3,7 @@ import json
 import time
 from asyncio.exceptions import TimeoutError as AIOTimeoutError
 
+import aiohttp
 from aiohttp.client_exceptions import ClientResponseError
 
 from .exceptions import DisconnectedError, TractiveError, UnauthorizedError
@@ -51,7 +52,10 @@ class Channel:
         while True:
             try:
                 async with self._api.session.request(
-                    "POST", self.CHANNEL_URL, headers=await self._api.auth_headers()
+                        "POST", self.CHANNEL_URL,
+                        headers=await self._api.auth_headers(),
+                        timeout=aiohttp.ClientTimeout(total=None, connect=10, sock_connect=10, sock_read=None,
+                                                      ceil_threshold=5)
                 ) as response:
                     async for data in response.content:
                         event = json.loads(data)


### PR DESCRIPTION
As mentioned in the issue #40, by default, aiohttp has a [5 minutes timeout](https://docs.aiohttp.org/en/stable/client_quickstart.html#timeouts) defined.

By setting `sock_read` to None, it will keep the connection open, avoiding reconnects every 5 minutes