### PR TITLE
Add exception tests

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,47 @@
+"""Tests for exception classes."""
+
+from __future__ import annotations
+
+import pytest
+
+from aiotractive.exceptions import (
+    DisconnectedError,
+    NotFoundError,
+    TractiveError,
+    UnauthorizedError,
+)
+
+
+@pytest.mark.parametrize(
+    "exc_class", [UnauthorizedError, NotFoundError, DisconnectedError]
+)
+def test_subclasses_inherit_from_tractive_error(
+    exc_class: type[TractiveError],
+) -> None:
+    """Test that all exception classes inherit from TractiveError."""
+    assert issubclass(exc_class, TractiveError)
+    assert issubclass(TractiveError, Exception)
+
+
+def test_can_catch_specific_exception() -> None:
+    """Test that specific exception types can be caught directly."""
+    with pytest.raises(UnauthorizedError):
+        raise UnauthorizedError("Invalid credentials")
+
+
+def test_can_catch_as_base_exception() -> None:
+    """Test that all specific exceptions can be caught as TractiveError."""
+    for exc in [
+        UnauthorizedError("test"),
+        NotFoundError("test"),
+        DisconnectedError("test"),
+    ]:
+        with pytest.raises(TractiveError):
+            raise exc
+
+
+def test_exception_message_preserved() -> None:
+    """Test that exception message is preserved when converted to string."""
+    msg = "Something went wrong"
+    err = TractiveError(msg)
+    assert str(err) == msg


### PR DESCRIPTION
Add unit tests for exception classes covering inheritance hierarchy and error handling.

Part of #53

## Tests Added
- `test_subclasses_inherit_from_tractive_error` - Verifies UnauthorizedError, NotFoundError, and DisconnectedError inherit from TractiveError
- `test_can_catch_specific_exception` - Tests catching specific exception types directly
- `test_can_catch_as_base_exception` - Tests catching all specific exceptions as TractiveError
- `test_exception_message_preserved` - Verifies exception message is preserved in string representation