### PR TITLE
Return an empty dict from health_overview when the tracker doesn't support health/overview endpoint

### DIFF
--- a/aiotractive/api.py
+++ b/aiotractive/api.py
@@ -14,7 +14,7 @@ import aiohttp
 from aiohttp.client_exceptions import ClientResponseError
 from yarl import URL
 
-from .exceptions import NotFoundError, TractiveError, UnauthorizedError
+from .exceptions import BadRequestError, NotFoundError, TractiveError, UnauthorizedError
 
 CLIENT_ID = "625e533dc3c3b41c28a669f0"
 
@@ -89,6 +89,8 @@ class API:
                 raise UnauthorizedError from error
             if error.status == HTTPStatus.NOT_FOUND:
                 raise NotFoundError from error
+            if error.status == HTTPStatus.BAD_REQUEST:
+                raise BadRequestError from error
             raise TractiveError from error
         except Exception as error:
             raise TractiveError from error

--- a/aiotractive/exceptions.py
+++ b/aiotractive/exceptions.py
@@ -9,6 +9,10 @@ class UnauthorizedError(TractiveError):
     """When the server does not accept the API token."""
 
 
+class BadRequestError(TractiveError):
+    """When the server responds with 400."""
+
+
 class NotFoundError(TractiveError):
     """When the server responds with 404."""
 

--- a/aiotractive/trackable_object.py
+++ b/aiotractive/trackable_object.py
@@ -1,8 +1,12 @@
 """Representation of a Tractive trackable object (pet)."""
 
+import logging
 from typing import Any
 
 from .data_object import DataObject
+from .exceptions import BadRequestError
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TrackableObject(DataObject):
@@ -21,8 +25,14 @@ class TrackableObject(DataObject):
         Returns health_overview data from the APS API endpoint.
         Replaces the deprecated wellness_overview message.
         """
-        health_overview: dict[str, Any] = await self._api.request(
-            f"pet/{self._id}/health/overview",
-            base_url=self._api.APS_API_URL,
-        )
+        try:
+            health_overview: dict[str, Any] = await self._api.request(
+                f"pet/{self._id}/health/overview",
+                base_url=self._api.APS_API_URL,
+            )
+        except BadRequestError:
+            _LOGGER.info(
+                "Trackable object %s does not support health/overview", self._id
+            )
+            return {}
         return health_overview


### PR DESCRIPTION
Related to https://github.com/home-assistant/core/issues/162135